### PR TITLE
Travis tutorial modifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ jobs:
       name: Build and Test
       env:
         - APP_ID='830780ac-07be-4995-89d4-0645f1f0e95a'
+        - ENV='Travis CI'
         - APP_HOST='http://vuln-proxy:8020'
-        - ENV='travis-ci'
         - EXEC_CMD='docker-compose --file docker-micro.yml exec vuln-django'
       script:
         - docker-compose --file docker-micro.yml build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: generic
 
 env:
   global:
-    - APP_ENV='travis-ci'
+    - APP_ENV='Travis CI'
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    - master
+    - main
     - /^travis.*$/
 
 language: generic

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN pip install -r /opt/app/requirements.txt
 
 
 # Create a "micro" stage to run as a gunicorn container
-# Requires migrations to run after startup (see README)
 FROM base as micro
 ARG SERVER_PORT=8010
 ENV SERVER_PORT=${SERVER_PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install -r /opt/app/requirements.txt
 
 
 # Create a "micro" stage to run as a gunicorn container
-# Requires migrations to run after startup (see docker-micro.yml)
+# Requires migrations to run after startup (see README)
 FROM base as micro
 ARG SERVER_PORT=8010
 ENV SERVER_PORT=${SERVER_PORT}

--- a/docker-micro-scan.yml
+++ b/docker-micro-scan.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - API_KEY=${HAWK_API_KEY}
       - APP_ID=${APP_ID}
-      - APP_ENV="${APP_ENV:-Travis CI}"
+      - APP_ENV="${APP_ENV:-Development}"
       - HOST=${HOST:-http://vuln-proxy:8020}
     volumes:
       - .:/hawk

--- a/docker-micro.yml
+++ b/docker-micro.yml
@@ -21,7 +21,6 @@ services:
     depends_on:
       - db
     environment:
-      - DJANGO_ALLOWED_HOSTS=*
       - DJANGO_SUPERUSER_USERNAME=admin
       - DJANGO_SUPERUSER_PASSWORD=adminpassword
       - DJANGO_SUPERUSER_EMAIL=admin@example.com

--- a/scripts/delete-automations.sh
+++ b/scripts/delete-automations.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Prepare this repository for the Travis CI tutorial.
+# This script removes automation in case you'd like to recreate it manually.
 
 function clean-repo {
   echo Cleaning repository...
@@ -13,7 +13,7 @@ function clean-repo {
     .travis.yml \
     Dockerfile \
     docker-* \
-    nginx* \
+    nginx.default \
     Procfile \
     stackhawk* \
     start-server.sh
@@ -29,8 +29,9 @@ function cancel-clean {
 echo ///// DANGER! /////
 echo This script will DELETE most of the files in this project!
 echo Run this if you would like to clear all automation from this project
-echo so you can follow along with the Travis CI tutorial.
+echo so you can try rebuilding it yourself.
 echo
+echo ///// DANGER! /////
 read -p "Do you want to DELETE automation from this project? [y/N]" yn
 case $yn in
   [Yy]* ) clean-repo; break;;

--- a/scripts/travis-prep.sh
+++ b/scripts/travis-prep.sh
@@ -3,18 +3,20 @@
 
 function clean-repo {
   echo Cleaning repository...
-  cd $(dirname $0) || exit 1
+  cd $(dirname $0)/.. || exit 1
   rm -rf \
     .circleci \
     scripts
-  rm \
+  rm -f \
     .gitlab-ci.yml \
-    .[A-Z]gitlab-ci.yml \
+    [A-Z]*.gitlab-ci.yml \
+    .travis.yml \
     Dockerfile \
-    docker-micro* \
+    docker-* \
     nginx* \
     Procfile \
-    stackhawk*
+    stackhawk* \
+    start-server.sh
   echo Complete!
   exit 0
 }
@@ -29,7 +31,7 @@ echo This script will DELETE most of the files in this project!
 echo Run this if you would like to clear all automation from this project
 echo so you can follow along with the Travis CI tutorial.
 echo
-read -p "Do you wish to DELETE automation from this project? [y/N]" yn
+read -p "Do you want to DELETE automation from this project? [y/N]" yn
 case $yn in
   [Yy]* ) clean-repo; break;;
   * ) cancel-clean;;

--- a/scripts/travis-prep.sh
+++ b/scripts/travis-prep.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Prepare this repository for the Travis CI tutorial.
+
+function clean-repo {
+  echo Cleaning repository...
+  cd $(dirname $0) || exit 1
+  rm -rf \
+    .circleci \
+    scripts
+  rm \
+    .gitlab-ci.yml \
+    .[A-Z]gitlab-ci.yml \
+    Dockerfile \
+    docker-micro* \
+    nginx* \
+    Procfile \
+    stackhawk*
+  echo Complete!
+  exit 0
+}
+
+function cancel-clean {
+  echo Canceling
+  exit 0
+}
+
+echo ///// DANGER! /////
+echo This script will DELETE most of the files in this project!
+echo Run this if you would like to clear all automation from this project
+echo so you can follow along with the Travis CI tutorial.
+echo
+read -p "Do you wish to DELETE automation from this project? [y/N]" yn
+case $yn in
+  [Yy]* ) clean-repo; break;;
+  * ) cancel-clean;;
+esac

--- a/stackhawk.yml
+++ b/stackhawk.yml
@@ -71,3 +71,7 @@ hawk:
 #    maxDurationMinutes: 2 # (default)
 #  # Maximum time to wait for the scanner to start up
 #  startupTimeoutMinutes: 5 # (default)
+  config:
+    - "spider.processform=true"
+    - "spider.postform=false"
+    - "spider.handleParameters=IGNORE_VALUE"


### PR DESCRIPTION
A few modifications in support of our Travis CI / Docker Compose tutorial.

- Trigger Travis builds on push to `main`, not `master`.
- Use application environment "Travis CI" for scans
- Add a script to delete automations so the reader can follow along
- Add `hawk.config`s to prevent HawkScan from deleting the admin user account in `vuln_django`